### PR TITLE
1.2 - Modify sub-threshold exon plots

### DIFF
--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -1485,9 +1485,7 @@ def main():
     # generate plot of sub optimal regions
     fig = plots.low_exon_plot(low_raw_cov)
 
-
     if num_cores == 1:
-        print("blarg")
         all_plots = plots.all_gene_plots(raw_coverage)
 
     elif len(cov_summary.index) < int(args.limit) or int(args.limit) == -1:

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -66,8 +66,7 @@ class generatePlots():
 
     def low_exon_plot(self, low_raw_cov):
         """
-        Plot bp coverage of exon, used for those where coverage is given
-        threshold
+        Generate array of low exon plot values to pass into report
 
         Args:
             - low_raw_cov (df): df of raw coverage for exons with low
@@ -75,7 +74,7 @@ class generatePlots():
             - threshold (int): defined threshold level (default: 20)
 
         Returns:
-            - fig (figure): plots of low coverage regions
+            - low_exon_plots (list): list of lists with values for plots
         """
         print("Generating plots of low covered regions")
 
@@ -155,9 +154,6 @@ class generatePlots():
             gene_data = (
                 f"""'<div class="sub_plot">{title},{x_vals},{y_vals}</div>'"""
             )
-
-            # for i in range(0, 10):
-            #     low_exon_plots.append(gene_data)
 
             low_exon_plots.append(gene_data)
 

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -132,7 +132,6 @@ class generatePlots():
                 col_no += 1
                 row_no = 1
             """
-            gene_data = []
             fig = go.Figure()
 
             # get rows for current gene and exon
@@ -232,26 +231,21 @@ class generatePlots():
             if sum(exon_cov_unbinned["cov"]) == 0:
                 continue
 
-            x_vals = exon_cov_unbinned['cov_start'].tolist()
-            y_vals = exon_cov_unbinned['cov'].tolist()
-            title = f"[{gene[0]} exon {gene[1]}]"
+            # build div str of plot data to pass to template
+            x_vals = str(exon_cov_unbinned['cov_start'].tolist()).strip('[]')
+            y_vals = str(exon_cov_unbinned['cov'].tolist()).strip('[]')
+            title = f"{gene[0]} exon {gene[1]}"
 
-            # print(x_vals)
-            # print(y_vals)
-            # print(title)
+            gene_data = (
+                f"""'<div class="sub_plot">{title},{x_vals},{y_vals}</div>'"""
+            )
 
-            gene_data.append(title)
-            gene_data.append(x_vals)
-            gene_data.append(y_vals)
+            # for i in range(0, 10):
+            #     low_exon_plots.append(gene_data)
 
-            for i in range(0, 10):
-                low_exon_plots.append(gene_data)
-
-        # print(low_exon_plots)
-
-        # print(len(low_exon_plots))
-        # print(len(low_exon_plots[0]))
-        # sys.exit()
+            low_exon_plots.append(gene_data)
+        
+        low_exon_plots = ','.join(low_exon_plots)
 
         return low_exon_plots
 

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -148,15 +148,11 @@ class generatePlots():
             y_vals = str(exon_cov_unbinned['cov'].tolist()).strip('[]')
             title = f"{gene[0]} exon {gene[1]}"
 
-            # format string to pass values to report
             gene_data = (
                 f"""'<div class="sub_plot">{title},{x_vals},{y_vals}</div>'"""
             )
 
             low_exon_plots.append(gene_data)
-
-            for i in range(30):
-                low_exon_plots.append(gene_data)
 
         low_exon_plots = ','.join(low_exon_plots)
 

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -103,6 +103,7 @@ class generatePlots():
             low_raw_cov["cov_end"] + low_raw_cov["cov_start"]) / 2
         ))
 
+        """
         # set no. rows to no. of plots / no of columns to define grid
         columns = 4
         rows = math.ceil(len(genes) / 4)
@@ -120,13 +121,19 @@ class generatePlots():
         # counter for grid
         row_no = 1
         col_no = 1
+        """
+        low_exon_plots = []
 
         for gene in genes:
             # make plot for each gene / exon
+            """
             if row_no // 5 == 1:
                 # counter for grid, gets to 5th entry & starts new row
                 col_no += 1
                 row_no = 1
+            """
+            gene_data = []
+            fig = go.Figure()
 
             # get rows for current gene and exon
             exon_cov = low_raw_cov.loc[(
@@ -176,48 +183,77 @@ class generatePlots():
             # info field for hovering on plot line
             label = '<i>position: </i>%{x}<br>coverage: %{y}<extra></extra>'
 
-            # generate plot and threshold line to display
-            if sum(exon_cov_unbinned["cov"]) != 0:
-                plot = go.Scatter(
-                    x=exon_cov_unbinned["cov_start"], y=exon_cov_unbinned["cov"],
-                    mode="lines",
-                    hovertemplate=label
-                )
-            else:
-                # if any plots have no coverage, just display empty plot
-                # very hacky way by making data point transparent but
-                # ¯\_(ツ)_/¯
-                plot = go.Scatter(
-                    x=exon_cov_unbinned["cov_start"], y=exon_cov_unbinned["cov"],
-                    mode="markers", marker={"opacity": 0}
-                )
+            # # generate plot and threshold line to display
+            # if sum(exon_cov_unbinned["cov"]) != 0:
+            #     plot = fig.add_trace(go.Scatter(
+            #         x=exon_cov_unbinned["cov_start"], y=exon_cov_unbinned["cov"],
+            #         mode="lines",
+            #         hovertemplate=label
+            #     ))
+            # else:
+            #     # if any plots have no coverage, just display empty plot
+            #     # very hacky way by making data point transparent but
+            #     # ¯\_(ツ)_/¯
+            #     plot = fig.add_trace(go.Scatter(
+            #         x=exon_cov_unbinned["cov_start"], y=exon_cov_unbinned["cov"],
+            #         mode="markers", marker={"opacity": 0}
+            #     ))
 
-            threshold_line = go.Scatter(
-                x=xval, y=yval, hoverinfo='skip', mode="lines",
-                line=dict(color='rgb(205, 12, 24)', width=1)
-            )
+            # threshold_line = fig.add_trace(go.Scatter(
+            #     x=xval, y=yval, hoverinfo='skip', mode="lines",
+            #     line=dict(color='rgb(205, 12, 24)', width=1)
+            #     ))
 
             # add to subplot grid
-            fig.add_trace(plot, col_no, row_no)
-            fig.add_trace(threshold_line, col_no, row_no)
+            # fig.add_trace(plot, col_no, row_no)
+            # fig.add_trace(threshold_line, col_no, row_no)
 
-            row_no = row_no + 1
+            # row_no = row_no + 1
 
         # set height of grid by no. rows and scale value of 325
-        height = (rows * 300) + 150
+        # height = (rows * 300) + 150
 
-        # update plot formatting
-        fig.update_xaxes(nticks=3, ticks="", showgrid=True, tickformat=',d')
-        fig.update_yaxes(title='coverage', title_standoff=0)
-        fig.update_xaxes(title='exon position', color='#FFFFFF')
-        fig["layout"].update(
-            height=height, showlegend=False, margin=dict(l=50, r=0)
-        )
+        
 
-        # write plots to html string
-        fig = fig.to_html(full_html=False)
+            # update plot formatting
+            # fig.update_xaxes(nticks=3, ticks="", showgrid=True, tickformat=',d')
+            # fig.update_yaxes(title='coverage', title_standoff=0)
+            # fig.update_xaxes(title='exon position', color='#FFFFFF')
+            # fig["layout"].update(
+            #     showlegend=False, margin=dict(l=50, r=0),
+            # )
 
-        return fig
+            # # write plots to html string
+            # fig = fig.to_html(full_html=False)
+
+            # # print(fig)
+            # print(len(fig.encode('utf-8')) / 1024 / 1024)
+
+            if sum(exon_cov_unbinned["cov"]) == 0:
+                continue
+
+            x_vals = exon_cov_unbinned['cov_start'].tolist()
+            y_vals = exon_cov_unbinned['cov'].tolist()
+            title = f"[{gene[0]} exon {gene[1]}]"
+
+            # print(x_vals)
+            # print(y_vals)
+            # print(title)
+
+            gene_data.append(title)
+            gene_data.append(x_vals)
+            gene_data.append(y_vals)
+
+            for i in range(0, 10):
+                low_exon_plots.append(gene_data)
+
+        # print(low_exon_plots)
+
+        # print(len(low_exon_plots))
+        # print(len(low_exon_plots[0]))
+        # sys.exit()
+
+        return low_exon_plots
 
 
     def all_gene_plots(self, raw_coverage):

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -390,13 +390,34 @@ class generatePlots():
 
         plt.legend(
             handles=[green, orange, red], loc='upper center',
-            bbox_to_anchor=(0.5, -0.15),
+            bbox_to_anchor=(0.5, -0.18),
             fancybox=True, shadow=True, ncol=12, fontsize=14
         )
 
         vals = np.arange(0, 110, 10).tolist()
         plt.yticks(vals, vals)
-        axs.tick_params(axis='both', which='major', labelsize=12)
+
+        if len(summary_data.index) > 250:
+            # x axis label overlap on lots of genes => skip every third
+            # shouldn't be a huge amount more than this to stop overlap
+            axs.set_xticks(axs.get_xticks()[::3])
+            axs.tick_params(axis='both', which='major', labelsize=10)
+            plt.figtext(
+                0.5, 0.1,
+                "Some gene labels are not shown due to high number of genes",
+                ha="center", fontsize=12
+            )
+        elif len(summary_data.index) > 125:
+            # x axis label overlap on lots of genes => skip every second
+            axs.set_xticks(axs.get_xticks()[::2])
+            axs.tick_params(axis='both', which='major', labelsize=10)
+            plt.figtext(
+                0.5, 0.1,
+                "Some gene labels are not shown due to high number of genes",
+                ha="center", fontsize=12
+            )
+        else:
+            axs.tick_params(axis='both', which='major', labelsize=10)
 
         plt.xlabel("")
         plt.ylabel("% coverage ({})".format(self.threshold), fontsize=11)

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -160,7 +160,7 @@ class generatePlots():
             #     low_exon_plots.append(gene_data)
 
             low_exon_plots.append(gene_data)
-        
+
         low_exon_plots = ','.join(low_exon_plots)
 
         return low_exon_plots
@@ -350,6 +350,7 @@ class generatePlots():
                 genes100pct = len(summary_data.iloc[:-100])
                 summary_data = summary_data.iloc[-100:]
 
+        # generate the plot
         plt.bar(
             summary_data["gene"],
             [int(x) for x in summary_data[self.threshold]],
@@ -357,8 +358,8 @@ class generatePlots():
         )
 
         if genes100pct is not None:
-            genes100pct = str(genes100pct)
             # more than 100 genes, add title inc. 100% covered not shown
+            genes100pct = str(genes100pct)
             axs.set_title(
                 r"$\bf{" + genes100pct + "}$" + " genes covered 100% at " +
                 r"$\bf{" + self.threshold + "}$" +
@@ -392,13 +393,13 @@ class generatePlots():
 
         plt.legend(
             handles=[green, orange, red], loc='upper center',
-            bbox_to_anchor=(0.5, -0.1),
-            fancybox=True, shadow=True, ncol=12, fontsize=12
+            bbox_to_anchor=(0.5, -0.15),
+            fancybox=True, shadow=True, ncol=12, fontsize=14
         )
 
         vals = np.arange(0, 110, 10).tolist()
         plt.yticks(vals, vals)
-        axs.tick_params(axis='both', which='major', labelsize=8)
+        axs.tick_params(axis='both', which='major', labelsize=12)
 
         plt.xlabel("")
         plt.ylabel("% coverage ({})".format(self.threshold), fontsize=11)

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -74,7 +74,7 @@ class generatePlots():
             - threshold (int): defined threshold level (default: 20)
 
         Returns:
-            - low_exon_plots (list): list of lists with values for plots
+            - low_exon_plots (str): list of plot values in div tags
         """
         print("Generating plots of low covered regions")
 
@@ -92,8 +92,6 @@ class generatePlots():
 
         # sort list of genes/exons by gene and exon
         genes = sorted(genes, key=lambda element: (element[0], element[1]))
-
-        plot_titles = [str(x[0]) + " exon: " + str(int(x[1])) for x in genes]
 
         low_raw_cov["exon_len"] =\
             low_raw_cov["exon_end"] - low_raw_cov["exon_start"]
@@ -156,6 +154,9 @@ class generatePlots():
             )
 
             low_exon_plots.append(gene_data)
+
+            for i in range(30):
+                low_exon_plots.append(gene_data)
 
         low_exon_plots = ','.join(low_exon_plots)
 

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -103,37 +103,9 @@ class generatePlots():
             low_raw_cov["cov_end"] + low_raw_cov["cov_start"]) / 2
         ))
 
-        """
-        # set no. rows to no. of plots / no of columns to define grid
-        columns = 4
-        rows = math.ceil(len(genes) / 4)
-
-        # variable height depeendent on no. of plots
-        v_space = (1 / rows) * 0.25
-
-        # define grid to add plots to
-        fig = make_subplots(
-            rows=rows, cols=columns, print_grid=False,
-            horizontal_spacing=0.04, vertical_spacing=v_space,
-            subplot_titles=plot_titles
-        )
-
-        # counter for grid
-        row_no = 1
-        col_no = 1
-        """
-        low_exon_plots = []
+        low_exon_plots = []  # array to add string data of plots to
 
         for gene in genes:
-            # make plot for each gene / exon
-            """
-            if row_no // 5 == 1:
-                # counter for grid, gets to 5th entry & starts new row
-                col_no += 1
-                row_no = 1
-            """
-            fig = go.Figure()
-
             # get rows for current gene and exon
             exon_cov = low_raw_cov.loc[(
                 low_raw_cov["gene"] == gene[0]
@@ -171,63 +143,6 @@ class generatePlots():
                         pos_row, ignore_index=True
                     )
 
-            # build list of first and last point for threshold line
-            xval = [x for x in range(
-                exon_cov_unbinned["cov_start"].iloc[0],
-                exon_cov_unbinned["cov_end"].iloc[-1]
-            )]
-            xval = xval[::len(xval) - 1]
-            yval = [self.threshold] * 2
-
-            # info field for hovering on plot line
-            label = '<i>position: </i>%{x}<br>coverage: %{y}<extra></extra>'
-
-            # # generate plot and threshold line to display
-            # if sum(exon_cov_unbinned["cov"]) != 0:
-            #     plot = fig.add_trace(go.Scatter(
-            #         x=exon_cov_unbinned["cov_start"], y=exon_cov_unbinned["cov"],
-            #         mode="lines",
-            #         hovertemplate=label
-            #     ))
-            # else:
-            #     # if any plots have no coverage, just display empty plot
-            #     # very hacky way by making data point transparent but
-            #     # ¯\_(ツ)_/¯
-            #     plot = fig.add_trace(go.Scatter(
-            #         x=exon_cov_unbinned["cov_start"], y=exon_cov_unbinned["cov"],
-            #         mode="markers", marker={"opacity": 0}
-            #     ))
-
-            # threshold_line = fig.add_trace(go.Scatter(
-            #     x=xval, y=yval, hoverinfo='skip', mode="lines",
-            #     line=dict(color='rgb(205, 12, 24)', width=1)
-            #     ))
-
-            # add to subplot grid
-            # fig.add_trace(plot, col_no, row_no)
-            # fig.add_trace(threshold_line, col_no, row_no)
-
-            # row_no = row_no + 1
-
-        # set height of grid by no. rows and scale value of 325
-        # height = (rows * 300) + 150
-
-        
-
-            # update plot formatting
-            # fig.update_xaxes(nticks=3, ticks="", showgrid=True, tickformat=',d')
-            # fig.update_yaxes(title='coverage', title_standoff=0)
-            # fig.update_xaxes(title='exon position', color='#FFFFFF')
-            # fig["layout"].update(
-            #     showlegend=False, margin=dict(l=50, r=0),
-            # )
-
-            # # write plots to html string
-            # fig = fig.to_html(full_html=False)
-
-            # # print(fig)
-            # print(len(fig.encode('utf-8')) / 1024 / 1024)
-
             if sum(exon_cov_unbinned["cov"]) == 0:
                 continue
 
@@ -236,6 +151,7 @@ class generatePlots():
             y_vals = str(exon_cov_unbinned['cov'].tolist()).strip('[]')
             title = f"{gene[0]} exon {gene[1]}"
 
+            # format string to pass values to report
             gene_data = (
                 f"""'<div class="sub_plot">{title},{x_vals},{y_vals}</div>'"""
             )

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -317,7 +317,7 @@
         var table = $('#low_plots_grid').DataTable({
             data: data,
             deferRender:    true,
-            scrollY:        "85vh",
+            scrollY:        "80vh",
             scrollX:        true,
             "searching":    false,
             "lengthMenu":   [[15, 30, 60, -1], [15, 30, 60, "All"]],
@@ -366,6 +366,7 @@
                     var text = [];
                     coords.forEach((coord, index) => {
                         const cov_val = cov[index];
+                        var coord = String(coord).replace(/\B(?=(\d{3})+(?!\d))/g, ","); // adds ',' seperator at 1000s
                         text.push("position: " + coord + "<br>coverage: " + cov_val);
                     });
 

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -257,6 +257,7 @@
             </span>
         </div>    
 
+
     <!-- DataTables function for calling plotly for low exon plots -->
     <script>
         jQuery.fn.dataTable.ext.type.search.hiddenVal = function(data) {
@@ -318,9 +319,13 @@
             data: data,
             deferRender:    true,
             scrollY:        "75vh",
-            scrollX:true,
-            "searching": false,
-            "lengthMenu": [[15, 30, 60, -1], [15, 30, 60, "All"]],
+            scrollX:        true,
+            "searching":    false,
+            "lengthMenu":   [[15, 30, 60, -1], [15, 30, 60, "All"]],
+            'processing':   true,
+            'language': {
+                'processing': 'Loading...'
+            },
             
             "preDrawCallback": function (oSettings) {
                 // function to create responsive container over dataTable for adding plots to
@@ -334,7 +339,7 @@
                 return true;
                 }
             },   
-            
+
             "rowCallback": function( nRow, data, iDisplayIndex, iDisplayIndexFull ) {
             // function to add data from array into container
                 if(gridview == 1) {  
@@ -438,9 +443,6 @@
             window.getSelection().removeAllRanges();
         }
     </script>
-
-
-
     </div>
 </body>
 </html>

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -25,7 +25,7 @@
         body {
             padding-top: 100;
             padding-bottom: 150;
-            width: 90%;
+            width: 85%;
             margin-left: auto;
             margin-right: auto;
             font-size:18px;
@@ -76,8 +76,6 @@
 
         /* low exon plot styling */
         #plot_container {
-            /* padding: 10px; */
-            /* margin: 10px; */
             width: 100%;
         }
         .sub_plot {
@@ -171,7 +169,6 @@
                 </thead>
             </table>
 
-            <br></br><br></br>
             <br></br><br></br>
 
             <div id="gene">

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -13,6 +13,11 @@
     <script type="text/javascript" language="javascript" src="https://cdn.datatables.net/plug-ins/1.10.25/features/pageResize/dataTables.pageResize.min.js"></script>
     <script type="text/javascript" src="https://cdn.plot.ly/plotly-1.42.5.min.js"></script>
 
+
+    <!-- testing -->
+    <link href="http://rawgit.com/vedmack/yadcf/master/jquery.dataTables.yadcf.css" rel="stylesheet" type="text/css" />
+    <script src="http://rawgit.com/vedmack/yadcf/master/jquery.dataTables.yadcf.js"></script>
+
     <style>
         /*  bootstrap passed as string from static/css*/ 
         $bootstrap
@@ -67,6 +72,29 @@
             max-height: 0;
             overflow: hidden;
             transition: max-height 0.5s ease-out;
+        }
+
+        /* low exon plot styling */
+        #plot_container {
+            /* padding: 10px; */
+            /* margin: 10px; */
+            width: 100%;
+        }
+        .sub_plot {
+            display: block;
+            float: left;
+            padding: 0px;
+            margin: 0px;
+            position: relative;
+            height: 400px;
+            width: 33%;
+        }
+        .sub_plot img {
+            border: 1px solid #333;
+        }
+        .svg-container {
+            padding: 0px;
+            margin: 0px;
         }
     </style>
 </head>
@@ -133,10 +161,16 @@
             an interactive window on hovering, showing the coverage at that current base.<br>
             The top right also contains a toolbar, with functions such as panning and zooming.
 
-            <!-- $low_cov_plots -->
-
             <br></br><br></br>
-            <div id="low_cov_plots_div" style="width: 100%; height:75vh;"></div>
+            <!-- table for low exon plots -->
+            <table id="low_plots_grid" style="display: none;" width="100%">
+                <thead>
+                  <tr>
+                      <th>Plot</th>          
+                  </tr>
+                </thead>
+            </table>
+
             <br></br><br></br>
             <br></br><br></br>
 
@@ -223,119 +257,146 @@
             </span>
         </div>    
 
-
     <!-- DataTables function for calling plotly for low exon plots -->
     <script>
-        $(document).ready(function () {
+        jQuery.fn.dataTable.ext.type.search.hiddenVal = function(data) {
+            return $('<div>').append(data).find('.hidden-val').text()
+        }
+        var gridview = 1;
 
-        queryData = 
+        $(document).ready( function () {
+        // data passed in as an array with plot title, coordinates and coverage values
+        var data = [
             $low_cov_plots
-        ;
+        ];
 
+        // plotly layout properties  
         let layout = {
-            // autosize: true,
             hovermode:'closest',        
             title: "",
-            width: 650,
-            height: 400,
-            
+            showlegend: false,
+            // width: '400px',
+            // // height: '25%',
+            shapes: [{
+                // threshold line
+                type: 'line',
+                xref: 'paper',
+                x0: 0,
+                y0: '',
+                x1: 1,
+                y1: '',
+                line:{
+                    color: 'rgb(255, 0, 0)',
+                    width: 1
+                }
+            }],
             xaxis: {
                 showgrid: false,
                 showline: false,
                 showticklabels: false,
             },
             yaxis: {
-            title: "coverage",
-            rangemode: "tozero"
+                title: "coverage",
+                rangemode: "tozero"
             }
-        //         paper_bgcolor: "rgba(0,0,0,0)",
-        //         plot_bgcolor: ""
-            };
+        };
 
+        // config for plotly to pass data to
         let dataConfig = [{
-            mode: "line",
+            mode: "lines",
             x: [],
             y: [],
-        hovertemplate: '%{y}'
-
+            text:'text',
+            hoverinfo: 'text',
+            line: {
+                color: '',
+                width: 2
+            }
         }];
 
-        $('#low_cov_plots_div').html('<table id="example" class="display" style="height:100% width:100%"></table>');
-        $('#example').dataTable({
-        //         "order": [],
-            "data": queryData,
-            "deferRender":    true,
-            "info":       true, 
-            "scrollY":        "75vh",
-            // "scrollCollapse": true,
-            responsive: true,
-            "scroller":       true,
-            "scroller": {
-            "loadingIndicator": true
-            },
-            'language': {
-                'loadingRecords': 'Loading...<br></br>',
-            },
-            "columns": [
-            { "title": "gene", visible: false },
-            { "title": ""}
-            ],
-            "columnDefs": [
-                {
-                    "targets": [ 0 ],
-                    "searchable": false,
-                    "sortable": false,
-        //                 "visible" : true,
-                    "render": function (data, type, full) { return full[0]; }
-                },
-                {
-                    "targets": [1],
-                    // "orderData" : 0,
-                    "searchable": true,
-                    "sortable": false,
-                    "render": function (data, type, full)
-                    {
-                        //return data;
-                        return '<div class="plotly_datatable_gauge">' + data + '</div>';
-                    }
+        var table = $('#low_plots_grid').DataTable({
+            data: data,
+            deferRender:    true,
+            scrollY:        "75vh",
+            scrollX:true,
+            "searching": false,
+            "lengthMenu": [[15, 30, 60, -1], [15, 30, 60, "All"]],
+            
+            "preDrawCallback": function (oSettings) {
+                // function to create responsive container over dataTable for adding plots to
+                if(gridview == 1) {
+                    // create an empty plot container, put it in the dataTables_scrollbody div
+                        if ($('#plot_container').length < 1) { 
+                            $('.dataTables_scrollBody').append('<div id="plot_container"></div>'); 
+                        } 
+                        $('#plot_container').html('');
+
+                return true;
                 }
-            ],
-            "rowCallback": function( row, data ) {
-            $('td:eq(0)', row).html('<div class="plotly_datatable_gauge">' + data + '</div>');
+            },   
+            
+            "rowCallback": function( nRow, data, iDisplayIndex, iDisplayIndexFull ) {
+            // function to add data from array into container
+                if(gridview == 1) {  
+                    $('#plot_container').append(data);
+                }
+                return nRow
             },
-            "drawCallback": function (Settings) {
-                $('.plotly_datatable_gauge').each(function() {
+            
+            "drawCallback": function (oSettings, data) {
+                // function to generate plots on every search / refresh
+                $('.sub_plot').each(function(data) {
+                    // calls plotly on each set of plot data in the container
                     let div = $(this)[0];
-                    
-                    // given array has coordinates and coverage values, split in half to get seperate
+
+                    // given array has title, coordinates and coverage values, split in half to seperate
                     let array = [div.innerHTML][0].split(",")
                     var coords = array.splice(1, Math.floor(array.length / 2));
-                    var cov = array.splice(1);
-                    var title = array[0]
-                    
-                
+                    var cov = array.splice(1);                
+                    var title = array[0];
+
+                    // random colour for plot line
+                    var r = () => Math.random() * 256 >> 0;
+                    var color = `rgb(${r()}, ${r()}, ${r()})`;
+
+                    // build text for hover labels on data points
+                    var text = [];
+                    coords.forEach((coord, index) => {
+                        const cov_val = cov[index];
+                        text.push("position: " + coord + "<br>coverage: " + cov_val);
+                    });
+
+                    // value for threshold line
+                    var threshold = '$threshold';
+                    threshold = parseInt(threshold.slice(0, -1));
+
                     // pass in to config for plotly
                     let t_dataConfig = dataConfig;
                     t_dataConfig[0].x = coords;
                     t_dataConfig[0].y = cov;
+                    t_dataConfig[0].line.color = color;
+                    t_dataConfig[0].text = text;
+                    layout.shapes[0].y0 = threshold;
+                    layout.shapes[0].y1 = threshold;
+                    layout.title = title;
 
-                    layout.title = title
-                    
-                    console.log(layout)
-                
                     while(div.firstChild) { div.removeChild(div.firstChild); }
-                    // call plotly to generate plot
-                    Plotly.react(
-                        div,
-                        t_dataConfig,
-                        layout,
-        //                     { displayModeBar: true, responsive: true, displaylogo: false }
-                    );
+                        // call plotly to generate plot
+                        Plotly.react(
+                            div,
+                            t_dataConfig,
+                            layout,
+                            {
+                                displaylogo: false,
+                                modeBarButtonsToRemove: [
+                                    'hoverClosestCartesian', 'hoverCompareCartesian', 'toggleSpikelines'
+                                ]
+                            }
+                        );
                 });
             }
         });
-        });
-
+    });
     </script>
 
 

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css">
+	<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/scroller/2.0.3/css/scroller.dataTables.min.css">
+	<link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap4.min.css">
+
+	<script type="text/javascript" language="javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
+	<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.min.js"></script>
+	<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/scroller/2.0.3/js/dataTables.scroller.min.js"></script>
+    <script type="text/javascript" language="javascript" src="https://cdn.datatables.net/plug-ins/1.10.25/features/pageResize/dataTables.pageResize.min.js"></script>
+    <script type="text/javascript" src="https://cdn.plot.ly/plotly-1.42.5.min.js"></script>
+
     <style>
         /*  bootstrap passed as string from static/css*/ 
         $bootstrap
@@ -122,8 +133,13 @@
             an interactive window on hovering, showing the coverage at that current base.<br>
             The top right also contains a toolbar, with functions such as panning and zooming.
 
-            $low_cov_plots
-        
+            <!-- $low_cov_plots -->
+
+            <br></br><br></br>
+            <div id="low_cov_plots_div" style="width: 100%; height:75vh;"></div>
+            <br></br><br></br>
+            <br></br><br></br>
+
             <div id="gene">
                 <!-- Per gene table and plots -->
                 <h2> Per gene coverage summary </h2>
@@ -207,6 +223,122 @@
             </span>
         </div>    
 
+
+    <!-- DataTables function for calling plotly for low exon plots -->
+    <script>
+        $(document).ready(function () {
+
+        queryData = 
+            $low_cov_plots
+        ;
+
+        let layout = {
+            // autosize: true,
+            hovermode:'closest',        
+            title: "",
+            width: 650,
+            height: 400,
+            
+            xaxis: {
+                showgrid: false,
+                showline: false,
+                showticklabels: false,
+            },
+            yaxis: {
+            title: "coverage",
+            rangemode: "tozero"
+            }
+        //         paper_bgcolor: "rgba(0,0,0,0)",
+        //         plot_bgcolor: ""
+            };
+
+        let dataConfig = [{
+            mode: "line",
+            x: [],
+            y: [],
+        hovertemplate: '%{y}'
+
+        }];
+
+        $('#low_cov_plots_div').html('<table id="example" class="display" style="height:100% width:100%"></table>');
+        $('#example').dataTable({
+        //         "order": [],
+            "data": queryData,
+            "deferRender":    true,
+            "info":       true, 
+            "scrollY":        "75vh",
+            // "scrollCollapse": true,
+            responsive: true,
+            "scroller":       true,
+            "scroller": {
+            "loadingIndicator": true
+            },
+            'language': {
+                'loadingRecords': 'Loading...<br></br>',
+            },
+            "columns": [
+            { "title": "gene", visible: false },
+            { "title": ""}
+            ],
+            "columnDefs": [
+                {
+                    "targets": [ 0 ],
+                    "searchable": false,
+                    "sortable": false,
+        //                 "visible" : true,
+                    "render": function (data, type, full) { return full[0]; }
+                },
+                {
+                    "targets": [1],
+                    // "orderData" : 0,
+                    "searchable": true,
+                    "sortable": false,
+                    "render": function (data, type, full)
+                    {
+                        //return data;
+                        return '<div class="plotly_datatable_gauge">' + data + '</div>';
+                    }
+                }
+            ],
+            "rowCallback": function( row, data ) {
+            $('td:eq(0)', row).html('<div class="plotly_datatable_gauge">' + data + '</div>');
+            },
+            "drawCallback": function (Settings) {
+                $('.plotly_datatable_gauge').each(function() {
+                    let div = $(this)[0];
+                    
+                    // given array has coordinates and coverage values, split in half to get seperate
+                    let array = [div.innerHTML][0].split(",")
+                    var coords = array.splice(1, Math.floor(array.length / 2));
+                    var cov = array.splice(1);
+                    var title = array[0]
+                    
+                
+                    // pass in to config for plotly
+                    let t_dataConfig = dataConfig;
+                    t_dataConfig[0].x = coords;
+                    t_dataConfig[0].y = cov;
+
+                    layout.title = title
+                    
+                    console.log(layout)
+                
+                    while(div.firstChild) { div.removeChild(div.firstChild); }
+                    // call plotly to generate plot
+                    Plotly.react(
+                        div,
+                        t_dataConfig,
+                        layout,
+        //                     { displayModeBar: true, responsive: true, displaylogo: false }
+                    );
+                });
+            }
+        });
+        });
+
+    </script>
+
+
     <!-- function to conditionally hide SNPs div if SNPs option not passed -->
     <script>
         // $total_snps is int passed from report script, set to JS snp_check var on writing to template to check against
@@ -245,6 +377,9 @@
             window.getSelection().removeAllRanges();
         }
     </script>
+
+
+
     </div>
 </body>
 </html>

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -256,7 +256,7 @@
     <!-- https://datatables.net/forums/discussion/60148/grid-view-mode-for-datatables  -->
     <!-- It hides the datatable body and adds a container over the top to add plots as divs to, -->
     <!-- the number per row is then controlled by css styling on width. This then allows for -->
-    <!-- using datatables scrolling/pagination etc. and deferred rendering, this stops -->
+    <!-- using datatables scrolling/pagination etc. and deferred rendering, and stops -->
     <!-- reports crashing as it always just loads 15 plots initially -->
     <!-- Plotly config is defined in layout and dataConfig variables then plotting is -->
     <!-- controlled via drawCallback function -->
@@ -268,9 +268,7 @@
 
         $(document).ready( function () {
         // data passed in as an array with plot title, coordinates and coverage values
-        var data = [
-            $low_cov_plots
-        ];
+        var data = [ $low_cov_plots ];
 
         // plotly layout properties  
         let layout = {
@@ -331,7 +329,7 @@
             "preDrawCallback": function (oSettings) {
                 // function to create responsive container over dataTable for adding plots to
                 if(gridview == 1) {
-                    // create an empty plot container, put it in the dataTables_scrollbody div
+                    // create an empty plot container, put it in the dataTables_scrollBody div
                         if ($('#plot_container').length < 1) { 
                             $('.dataTables_scrollBody').append('<div id="plot_container"></div>'); 
                         } 
@@ -352,7 +350,6 @@
             "drawCallback": function (oSettings, data) {
                 // function to generate plots on every search / refresh
                 $('.sub_plot').each(function(data) {
-                    // calls plotly on each set of plot data in the container
                     let div = $(this)[0];
 
                     // given array has title, coordinates and coverage values, split in half to seperate
@@ -374,9 +371,9 @@
 
                     // value for threshold line
                     var threshold = '$threshold';
-                    threshold = parseInt(threshold.slice(0, -1));
+                    threshold = parseInt(threshold.slice(0, -1)); // remove x from end
 
-                    // pass in to config for plotly
+                    // pass values to config and layout for plotly
                     let t_dataConfig = dataConfig;
                     t_dataConfig[0].x = coords;
                     t_dataConfig[0].y = cov;

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -256,6 +256,15 @@
 
 
     <!-- DataTables function for calling plotly for low exon plots -->
+    <!-- Kinda hacky way to use datatables to display plots in a grid style since -->
+    <!-- datatables is meant for col/row data. Based off this question: -->
+    <!-- https://datatables.net/forums/discussion/60148/grid-view-mode-for-datatables  -->
+    <!-- It hides the datatable body and adds a container over the top to add plots as divs to, -->
+    <!-- the number per row is then controlled by css styling on width. This then allows for -->
+    <!-- using datatables scrolling/pagination etc. and deferred rendering, this stops -->
+    <!-- reports crashing as it always just loads 15 plots initially -->
+    <!-- Plotly config is defined in layout and dataConfig variables then plotting is -->
+    <!-- controlled via drawCallback function -->
     <script>
         jQuery.fn.dataTable.ext.type.search.hiddenVal = function(data) {
             return $('<div>').append(data).find('.hidden-val').text()

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -13,11 +13,6 @@
     <script type="text/javascript" language="javascript" src="https://cdn.datatables.net/plug-ins/1.10.25/features/pageResize/dataTables.pageResize.min.js"></script>
     <script type="text/javascript" src="https://cdn.plot.ly/plotly-1.42.5.min.js"></script>
 
-
-    <!-- testing -->
-    <link href="http://rawgit.com/vedmack/yadcf/master/jquery.dataTables.yadcf.css" rel="stylesheet" type="text/css" />
-    <script src="http://rawgit.com/vedmack/yadcf/master/jquery.dataTables.yadcf.js"></script>
-
     <style>
         /*  bootstrap passed as string from static/css*/ 
         $bootstrap

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -315,7 +315,7 @@
         var table = $('#low_plots_grid').DataTable({
             data: data,
             deferRender:    true,
-            scrollY:        "75vh",
+            scrollY:        "85vh",
             scrollX:        true,
             "searching":    false,
             "lengthMenu":   [[15, 30, 60, -1], [15, 30, 60, "All"]],


### PR DESCRIPTION
- Rewritten how plots of exon with coverage beneath threshold are generated
- Coverage values and coordinates for each plot then passed in an array to template, where dataTables + plotly are used to generate the plots in a dataTable window
- Reduced plot file size from <1MB per plot to ~4KB
- Deferred rendering and pagination now allow the reports to handle hundreds of plots without crashing and no impact on initial load time
- Example output may be found at bottom of page here: https://cuhbioinformatics.atlassian.net/wiki/spaces/P/pages/2216230925/Development
- Fixes #2 #24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/athena/35)
<!-- Reviewable:end -->
