### PR TITLE
fix float precision of mean for gene stats

### DIFF
--- a/bin/coverage_stats_single.py
+++ b/bin/coverage_stats_single.py
@@ -280,11 +280,9 @@ class singleCoverage():
 
             # calculate gene coverage values
             min = gene_cov["min"].min()
-            mean = sum(
-                [x * y for x, y in zip(
-                    gene_cov["mean"], gene_cov["exon_frac"]
-                )]
-            )
+            mean = round(sum(
+                [x * y for x, y in zip(gene_cov["mean"], gene_cov["exon_frac"])]
+            ), 12)
             max = gene_cov["max"].max()
 
             # average coverage % at given thresholds, round to 12 dp to


### PR DESCRIPTION
- leaving 16+ decimal places for mean value results in differing levels of float precision when using `df.to_csv()`, since this level of precision is not needed for mean value round to 12 dp to match other values and gives identical output

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/athena/42)
<!-- Reviewable:end -->
