### PR TITLE
Fix making child kill parent successfully

### DIFF
--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -601,7 +601,7 @@ class styleTables():
             - total_genes (int): total number of genes
         """
         # rename columns for displaying in report
-        gene_stats = self.cov_summary.drop(columns=["exon"])
+        gene_stats = self.cov_summary.copy()
         gene_stats = gene_stats.rename(columns=self.column_names)
 
         # get values to display in report

--- a/bin/coverage_stats_single.py
+++ b/bin/coverage_stats_single.py
@@ -477,6 +477,11 @@ def main():
         else:
             cov_stats = pd.concat(pool_output, ignore_index=True)
 
+            # imap_unordered() returns everything out of order (funnily enough)
+            # sort by gene and exon to be nicely formatted
+            cov_stats.exon = cov_stats.exon.astype(int)
+            cov_stats = cov_stats.sort_values(['gene', 'exon'])
+
     # split up output coverage stats df for multiprocessing
     split_stats_dfs = np.asanyarray(
         [cov_stats[cov_stats["gene"].isin(x)] for x in gene_array],
@@ -491,6 +496,8 @@ def main():
                 single.summary_stats, map(
                     lambda e: (e, thresholds), split_stats_dfs
                 )), ignore_index=True)
+
+    cov_summary = cov_summary.sort_values(['gene'])
 
     # write tables to output files
     single.write_outfiles(

--- a/bin/coverage_stats_single.py
+++ b/bin/coverage_stats_single.py
@@ -498,6 +498,7 @@ def main():
                 )), ignore_index=True)
 
     cov_summary = cov_summary.sort_values(['gene'])
+    cov_summary = cov_summary.drop(columns=["exon"])
 
     # write tables to output files
     single.write_outfiles(


### PR DESCRIPTION
- Fixes issue with sys.exit() inside multiprocess causing map() to hang. Moved to raising an assertion and using imap_unordered() to catch the assertion and terminate the pool of child processes when there's an error
- https://docs.python.org/3.3/library/multiprocessing.html#multiprocessing.pool.Pool.imap_unordered
- Fixes #20
- Moved dropping empty exon column in gene level table from report to stats script - Fixes #26 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/athena/45)
<!-- Reviewable:end -->
