### PR TITLE
1.2 - add dataTables functionality to variant tables from VCFs

### DIFF
--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -597,7 +597,7 @@ class styleTables():
             - cov_summary (df): df of gene coverage stats
             - threshold_cols (list): list of threshold values
         Returns:
-            - gene_stats (str): HTML formatted str of gene summary df
+            - gene_stats (list): HTML formatted str of gene summary df
             - total_genes (int): total number of genes
         """
         # rename columns for displaying in report
@@ -632,7 +632,7 @@ class styleTables():
         Args:
             - snps_cov (df): df of snps above / below threshold
         Returns:
-            - snps_cov (str): list of snps to render in report
+            - snps_cov (list): list of snps to render in report
             - total_snps (int): total number of snps in df
         """
         if not snps_cov.empty:
@@ -667,15 +667,11 @@ class styleTables():
         Args:
             - snps_no_cov (df): df of snps with no coverage values
         Returns:
-            - snps_no_cov (str): list of snps for rendering in report
+            - snps_no_cov (list): list of snps for rendering in report
             - snps_out_panel (int): total number snps with no cov
         """
         # if variants from vcf found that span exon boundaries
         if not snps_no_cov.empty:
-            # manually add div and styling around rendered table, allows
-            # to be fully absent from the report if the table is empty
-            snps_no_cov.index = np.arange(1, len(snps_no_cov) + 1)
-
             # get number of variants to display in report
             snps_out_panel = len(snps_no_cov.index)
 

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -1173,8 +1173,6 @@ class generateReport():
 
         date = datetime.today().strftime('%Y-%m-%d')
 
-        print(snps_low_cov)
-
         single_report = t.safe_substitute(
             bootstrap=bootstrap,
             logo=logo,

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -626,31 +626,6 @@ class styleTables():
         return gene_stats, total_genes
 
 
-    def check_snp_tables(self, snps_low_cov, snps_high_cov):
-        """
-        Check styled tables, if empty replace with appropriate text
-
-        Args:
-            - snps_low_cov (str): HTML styled table of low covered snps
-            - snps_high_cov (str): HTML styled table of covered snps
-
-        Returns:
-            - snps_low_cov (str): HTML styled table of low covered snps
-            - snps_high_cov (str): HTML styled table of covered snps
-        """
-        if snps_low_cov is None:
-            snps_low_cov = "<b>No variants with coverage < {}</b>".format(
-                self.threshold
-            )
-
-        if snps_high_cov is None:
-            snps_high_cov = "<b>No variants covered at {}/b>".format(
-                self.threshold
-            )
-
-        return snps_low_cov, snps_high_cov
-
-
     def style_snps_cov(self, snps_cov):
         """
         Add styling to tables of SNPs covered above / beneath threshold
@@ -1117,9 +1092,6 @@ class generateReport():
         snps_low_cov, snps_not_covered = styling.style_snps_cov(snps_low_cov)
         snps_high_cov, snps_covered = styling.style_snps_cov(snps_high_cov)
         snps_no_cov, snps_out_panel = styling.style_snps_no_cov(snps_no_cov)
-        # snps_low_cov, snps_high_cov = styling.check_snp_tables(
-        #     snps_low_cov, snps_high_cov
-        # )
 
         # get values to display in report
         fully_covered_genes = total_genes - gene_issues

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -673,24 +673,31 @@ class styleTables():
 
             total_snps = len(snps_cov.index)
 
-            snps_cov = snps_cov.style\
-                .set_table_attributes(
-                    'class="dataframe table table-striped"')\
-                .set_uuid(uuid)\
-                .set_properties(**{
-                    'font-size': '0.80vw', 'table-layout': 'auto'
-                })\
-                .set_properties(subset=["VCF", "Gene"], **{'width': '10%'})\
-                .set_properties(subset=["Exon"], **{'width': '7.5%'})\
-                .set_properties(subset=["Chromosome"], **{'width': '10%'})\
-                .set_properties(subset=["Position"], **{'width': '12.5%'})\
-                .set_properties(subset=["Ref"], **{'width': '20%'})\
-                .set_properties(subset=["Alt"], **{'width': '20%'})\
-                .set_properties(subset=["Coverage"], **{'width': '10%'})
+            # reset index to start at 1
+            snps_cov.index = np.arange(1, len(snps_cov.index) + 1)
+            snps_cov.insert(0, 'index', snps_cov.index)
 
-            snps_cov = snps_cov.render()
+            # turn gene stats table into list of lists
+            snps_cov = snps_cov.values.tolist()
+
+            # snps_cov = snps_cov.style\
+            #     .set_table_attributes(
+            #         'class="dataframe table table-striped"')\
+            #     .set_uuid(uuid)\
+            #     .set_properties(**{
+            #         'font-size': '0.80vw', 'table-layout': 'auto'
+            #     })\
+            #     .set_properties(subset=["VCF", "Gene"], **{'width': '10%'})\
+            #     .set_properties(subset=["Exon"], **{'width': '7.5%'})\
+            #     .set_properties(subset=["Chromosome"], **{'width': '10%'})\
+            #     .set_properties(subset=["Position"], **{'width': '12.5%'})\
+            #     .set_properties(subset=["Ref"], **{'width': '20%'})\
+            #     .set_properties(subset=["Alt"], **{'width': '20%'})\
+            #     .set_properties(subset=["Coverage"], **{'width': '10%'})
+
+            # snps_cov = snps_cov.render()
         else:
-            snps_cov = None
+            snps_cov = []
             total_snps = 0
 
         return snps_cov, total_snps
@@ -715,38 +722,46 @@ class styleTables():
             # get number of variants to display in report
             snps_out_panel = len(snps_no_cov.index)
 
-            html_string = snps_no_cov.style\
-                .set_table_attributes(
-                    'class="dataframe table table-striped"')\
-                .set_uuid("var_no_cov")\
-                .set_properties(**{
-                    'font-size': '0.80vw', 'table-layout': 'auto'
-                })\
-                .set_properties(subset=["VCF"], **{
-                    'width': '7.5%'
-                })\
-                .set_properties(subset=[
-                    "Chromosome", "Position", "Ref", "Alt"
-                ], **{'width': '10%'})
+            # reset index to start at 1
+            snps_no_cov.index = np.arange(1, len(snps_no_cov.index) + 1)
+            snps_no_cov.insert(0, 'index', snps_no_cov.index)
 
-            html_string = html_string.render()
+            # turn gene stats table into list of lists
+            snps_no_cov = snps_no_cov.values.tolist()
 
-            snps_no_cov = """
-                <br> Variants included in the first table below either fully\
-                    or partially span panel region(s). These are most likely\
-                    large structural variants and as such do not have\
-                    coverage data available. See the "info" column for details\
-                    on the variant.
-                </br>
-                <br> Table of variants spanning panel regions(s) &nbsp
-                <button class="btn btn-info collapsible btn-sm">Show /\
-                     hide table</button>
-                <div class="content">
-                    <table>
-                        {}
-                    </table>
-                </div></br>
-                """.format(html_string)
+
+            # html_string = snps_no_cov.style\
+            #     .set_table_attributes(
+            #         'class="dataframe table table-striped"')\
+            #     .set_uuid("var_no_cov")\
+            #     .set_properties(**{
+            #         'font-size': '0.80vw', 'table-layout': 'auto'
+            #     })\
+            #     .set_properties(subset=["VCF"], **{
+            #         'width': '7.5%'
+            #     })\
+            #     .set_properties(subset=[
+            #         "Chromosome", "Position", "Ref", "Alt"
+            #     ], **{'width': '10%'})
+
+            # html_string = html_string.render()
+
+            # snps_no_cov = """
+            #     <br> Variants included in the first table below either fully\
+            #         or partially span panel region(s). These are most likely\
+            #         large structural variants and as such do not have\
+            #         coverage data available. See the "info" column for details\
+            #         on the variant.
+            #     </br>
+            #     <br> Table of variants spanning panel regions(s) &nbsp
+            #     <button class="btn btn-info collapsible btn-sm">Show /\
+            #          hide table</button>
+            #     <div class="content">
+            #         <table>
+            #             {}
+            #         </table>
+            #     </div></br>
+            #     """.format(html_string)
         else:
             snps_no_cov = ""
             snps_out_panel = 0
@@ -1102,9 +1117,9 @@ class generateReport():
         snps_low_cov, snps_not_covered = styling.style_snps_cov(snps_low_cov)
         snps_high_cov, snps_covered = styling.style_snps_cov(snps_high_cov)
         snps_no_cov, snps_out_panel = styling.style_snps_no_cov(snps_no_cov)
-        snps_low_cov, snps_high_cov = styling.check_snp_tables(
-            snps_low_cov, snps_high_cov
-        )
+        # snps_low_cov, snps_high_cov = styling.check_snp_tables(
+        #     snps_low_cov, snps_high_cov
+        # )
 
         # get values to display in report
         fully_covered_genes = total_genes - gene_issues
@@ -1186,6 +1201,8 @@ class generateReport():
 
         date = datetime.today().strftime('%Y-%m-%d')
 
+        print(snps_low_cov)
+
         single_report = t.safe_substitute(
             bootstrap=bootstrap,
             logo=logo,
@@ -1205,9 +1222,9 @@ class generateReport():
             gene_table_headings=report_vals["gene_table_headings"],
             exon_table_headings=report_vals["exon_table_headings"],
             total_stats=total_stats,
-            snps_high_cov=snps_high_cov,
-            snps_low_cov=snps_low_cov,
-            snps_no_cov=snps_no_cov,
+            snps_high_cov_data=snps_high_cov,
+            snps_low_cov_data=snps_low_cov,
+            snps_no_cov_data=snps_no_cov,
             total_snps=report_vals["total_snps"],
             snps_covered=report_vals["snps_covered"],
             snps_pct_covered=report_vals["snps_pct_covered"],

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -632,7 +632,7 @@ class styleTables():
         Args:
             - snps_cov (df): df of snps above / below threshold
         Returns:
-            - snps_cov (str): HTML formatted str of snps df
+            - snps_cov (str): list of snps to render in report
             - total_snps (int): total number of snps in df
         """
         if not snps_cov.empty:
@@ -645,7 +645,6 @@ class styleTables():
                 uuid = "var_low_cov"
 
             snps_cov.index = np.arange(1, len(snps_cov.index) + 1)
-
             total_snps = len(snps_cov.index)
 
             # reset index to start at 1
@@ -654,23 +653,6 @@ class styleTables():
 
             # turn gene stats table into list of lists
             snps_cov = snps_cov.values.tolist()
-
-            # snps_cov = snps_cov.style\
-            #     .set_table_attributes(
-            #         'class="dataframe table table-striped"')\
-            #     .set_uuid(uuid)\
-            #     .set_properties(**{
-            #         'font-size': '0.80vw', 'table-layout': 'auto'
-            #     })\
-            #     .set_properties(subset=["VCF", "Gene"], **{'width': '10%'})\
-            #     .set_properties(subset=["Exon"], **{'width': '7.5%'})\
-            #     .set_properties(subset=["Chromosome"], **{'width': '10%'})\
-            #     .set_properties(subset=["Position"], **{'width': '12.5%'})\
-            #     .set_properties(subset=["Ref"], **{'width': '20%'})\
-            #     .set_properties(subset=["Alt"], **{'width': '20%'})\
-            #     .set_properties(subset=["Coverage"], **{'width': '10%'})
-
-            # snps_cov = snps_cov.render()
         else:
             snps_cov = []
             total_snps = 0
@@ -685,7 +667,7 @@ class styleTables():
         Args:
             - snps_no_cov (df): df of snps with no coverage values
         Returns:
-            - snps_no_cov (str): HTML formatted str of snps with no cov
+            - snps_no_cov (str): list of snps for rendering in report
             - snps_out_panel (int): total number snps with no cov
         """
         # if variants from vcf found that span exon boundaries
@@ -703,42 +685,8 @@ class styleTables():
 
             # turn gene stats table into list of lists
             snps_no_cov = snps_no_cov.values.tolist()
-
-
-            # html_string = snps_no_cov.style\
-            #     .set_table_attributes(
-            #         'class="dataframe table table-striped"')\
-            #     .set_uuid("var_no_cov")\
-            #     .set_properties(**{
-            #         'font-size': '0.80vw', 'table-layout': 'auto'
-            #     })\
-            #     .set_properties(subset=["VCF"], **{
-            #         'width': '7.5%'
-            #     })\
-            #     .set_properties(subset=[
-            #         "Chromosome", "Position", "Ref", "Alt"
-            #     ], **{'width': '10%'})
-
-            # html_string = html_string.render()
-
-            # snps_no_cov = """
-            #     <br> Variants included in the first table below either fully\
-            #         or partially span panel region(s). These are most likely\
-            #         large structural variants and as such do not have\
-            #         coverage data available. See the "info" column for details\
-            #         on the variant.
-            #     </br>
-            #     <br> Table of variants spanning panel regions(s) &nbsp
-            #     <button class="btn btn-info collapsible btn-sm">Show /\
-            #          hide table</button>
-            #     <div class="content">
-            #         <table>
-            #             {}
-            #         </table>
-            #     </div></br>
-            #     """.format(html_string)
         else:
-            snps_no_cov = ""
+            snps_no_cov = []
             snps_out_panel = 0
 
         return snps_no_cov, snps_out_panel

--- a/bin/load_data.py
+++ b/bin/load_data.py
@@ -363,8 +363,7 @@ class loadData():
         if snp_vcfs:
             # get names of SNP vcfs used to display in report
             vcfs = ", ".join([Path(x).stem for x in snp_vcfs])
-            vcfs = "<br>VCF(s) of known variants included in report: <b>{}</b>\
-                </br>".format(vcfs)
+            vcfs = f"VCF(s) of known variants included in report: <b>{vcfs}</b>"
         else:
             vcfs = ""
 

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -339,6 +339,45 @@
 
     <!-- JS functions -->
 
+    <!-- function to conditionally hide SNPs div if SNPs option not passed -->
+    <script>
+        // $total_snps is int passed from report script, set to JS snp_check var on writing to template to check against
+        var snp_check = $total_snps
+        if (snp_check == 0) { 
+        document.getElementById('snps').style.display = "none";  
+        }
+    </script>
+
+
+    <!-- function to conditionally hide low exon plots div if no plots to display -->
+    <script>
+        // $exon_issues is int passed from report script
+        var exon_check = $exon_issues
+        if (exon_check == 0) { 
+        document.getElementById('low_exon_plots').style.display = "none";  
+        }
+    </script>
+
+
+    <!-- function to make sections collapsible -->
+    <script>
+        var coll = document.getElementsByClassName("collapsible");
+        var i;
+
+        for (i = 0; i < coll.length; i++) {
+        coll[i].addEventListener("click", function() {
+            this.classList.toggle("active");
+            var content = this.nextElementSibling;
+            if (content.style.maxHeight){
+            content.style.maxHeight = null;
+            } else {
+            content.style.maxHeight = content.scrollHeight * 2 + "px";
+            } 
+        });
+        }
+    </script>
+
+
     <!-- DataTables function for full plots -->
     <script type="text/javascript" class="init">
         $(document).ready(function() {
@@ -551,44 +590,6 @@
     </script>
 
 
-    <!-- function to conditionally hide SNPs div if SNPs option not passed -->
-    <script>
-        // $total_snps is int passed from report script, set to JS snp_check var on writing to template to check against
-        var snp_check = $total_snps
-        if (snp_check == 0) { 
-        document.getElementById('snps').style.display = "none";  
-        }
-    </script>
-
-
-    <!-- function to conditionally hide low exon plots div if no plots to display -->
-    <script>
-        // $exon_issues is int passed from report script
-        var exon_check = $exon_issues
-        if (exon_check == 0) { 
-        document.getElementById('low_exon_plots').style.display = "none";  
-        }
-    </script>
-
-    <!-- function to make sections collapsible -->
-    <script>
-        var coll = document.getElementsByClassName("collapsible");
-        var i;
-
-        for (i = 0; i < coll.length; i++) {
-        coll[i].addEventListener("click", function() {
-            this.classList.toggle("active");
-            var content = this.nextElementSibling;
-            if (content.style.maxHeight){
-            content.style.maxHeight = null;
-            } else {
-            content.style.maxHeight = content.scrollHeight * 2 + "px";
-            } 
-        });
-        }
-    </script>
-
-
     <!-- DataTables function for low exon coverage table -->
     <script type="text/javascript" class="init">
         function getColor(value){
@@ -720,6 +721,7 @@
             } );
         } );
     </script>
+
 
     <!-- DataTables function for variant table - sub-threshold coverage -->
     <script type="text/javascript" class="init">	

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -82,10 +82,6 @@
             transition: max-height 0.5s ease-out;
         }
 
-        /* .fullPlots tbody {
-            pointer-events: none;
-        }             */
-
         .noHover{
             pointer-events: none;
         }
@@ -266,7 +262,7 @@
 
                 <!-- snps_no_cov is div passed from script if variants spanning exon boundaries found -->
                 <div id="snps_no_cov">
-                    <b>Variants spanning gene/exon boundaries (e.g. larger structural variants)</b>
+                    <b>Variants spanning gene / exon boundaries (e.g. larger structural variants)</b>
                     <!-- Table for exon boundary spanning variants, data in JS function -->
                     <table id="snps_no_cov_table" class="display" style="width:100%; text-align:center">
                         <thead>
@@ -287,7 +283,7 @@
 
                 <!-- Table for sub threshold exon coverage, data in JS function -->
                 <div id="snps_low_cov">
-                    Table of variants with low coverage (< $threshold) &nbsp
+                    <b>Table of variants with low coverage (< $threshold)</b>
                     <table id="snps_low_cov_table" class="display" style="width:100%; text-align:center">
                         <thead>
                             <tr>
@@ -688,13 +684,10 @@
         $(document).ready(function() {
             var data = $snps_no_cov_data ;
 
-            if ($('data').length == 0) {
+            if (data.length == 0) {
                 // empty table, replace with text
                 document.getElementById('snps_low_cov').innerHTML = '';
-                // var h1 = document.createElement('h1');
-                // h1.innerHTML = "hello world!";
                 var text = "<b>No variants spanning gene / exon regions < $threshold</b>"
-                // document.getElementById('snps_low_cov').appendChild(text);
                 document.getElementById('snps_low_cov').innerHTML = text ;
             }
 
@@ -721,20 +714,17 @@
         $(document).ready(function() {
             var data = $snps_low_cov_data ;
 
-            if ($('data').length == 0) {
+            if (data.length == 0) {
                 // empty table, replace with text
                 document.getElementById('snps_low_cov').innerHTML = '';
-                // var h1 = document.createElement('h1');
-                // h1.innerHTML = "hello world!";
                 var text = "<b>No variants with coverage < $threshold</b>"
-                // document.getElementById('snps_low_cov').appendChild(text);
                 document.getElementById('snps_low_cov').innerHTML = text ;
             }
 
-            $('#snps_sub_threshold_table').DataTable( {
+            $('#snps_low_cov_table').DataTable( {
                 data:           data,
                 deferRender:    true,
-                scrollY:        500,
+                scrollY:        600,
                 scrollCollapse: true,
                 scroller:       true,
                 scroller: {
@@ -754,20 +744,17 @@
         $(document).ready(function() {
             var data = $snps_high_cov_data ;
 
-            if ($('data').length == 0) {
+            if (data.length == 0) {
                 // empty table, replace with text
-                document.getElementById('snps_low_cov').innerHTML = '';
-                // var h1 = document.createElement('h1');
-                // h1.innerHTML = "hello world!";
+                document.getElementById('snps_covered').innerHTML = '';
                 var text = "<b>No variants with coverage > $threshold</b>"
-                // document.getElementById('snps_low_cov').appendChild(text);
-                document.getElementById('snps_low_cov').innerHTML = text ;
+                document.getElementById('snps_covered').innerHTML = text ;
             }
 
             $('#snps_covered_table').DataTable( {
                 data:           data,
                 deferRender:    true,
-                scrollY:        500,
+                scrollY:        600,
                 scrollCollapse: true,
                 scroller:       true,
                 scroller: {

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -246,10 +246,12 @@
                     </thead>
                 </table>
             </div>
+
             <br><hr></br>
 
             <!-- Optional section for displaying SNP information if generated -->
             <div id="snps">
+                
                 <h2> Coverage of Known Variants </h2>
                 <br>
                 Below are tables giving coverage of known variants. The low coverage table gives those not covered at $threshold, 
@@ -302,21 +304,6 @@
                         </thead>
                     </table>
                 </div>
-
-                <!-- <button class="btn btn-info collapsible btn-sm">Show / hide table</button>
-                <div class="content">
-                    <table class="snps" style="table-layout: fixed; width:100%">
-                        $snps_low_cov
-                    </table>
-                </div> -->
-
-                <!-- 
-                <button class="btn btn-info collapsible btn-sm">Show / hide table</button>
-                <div class="content">
-                    <table class="snps" style="table-layout: fixed; width:100%">
-                        $snps_high_cov
-                    </table>
-                </div> -->
 
                 <br><hr></br>
 

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -176,21 +176,24 @@
 
                 </table>
             </div>
-            <br></br>
 
-            To assess what portion of the exon(s) have sub-optimal coverage, the plots below display 
-            an interactive window on hovering, showing the coverage at that current base.<br>
-            The top right also contains a toolbar, with functions such as panning and zooming.
+            <div id="low_exon_plots">
+                <br></br>
 
-            <br></br><br></br>
-            <!-- table for low exon plots -->
-            <table id="low_plots_grid" style="display: none;" width="100%">
-                <thead>
-                  <tr>
-                      <th>Plot</th>
-                  </tr>
-                </thead>
-            </table>
+                To assess what portion of the exon(s) have sub-optimal coverage, the plots below display 
+                an interactive window on hovering, showing the coverage at that current base.<br>
+                The top right also contains a toolbar, with functions such as panning and zooming.
+
+                <br></br>
+                <!-- table for low exon plots -->
+                <table id="low_plots_grid" style="display: none;" width="100%">
+                    <thead>
+                    <tr>
+                        <th>Plot</th>
+                    </tr>
+                    </thead>
+                </table>
+            </div>
 
             <br></br><hr><br></br>
 
@@ -334,6 +337,8 @@
         </div>
     </body>
 
+    <!-- JS functions -->
+
     <!-- DataTables function for full plots -->
     <script type="text/javascript" class="init">
         $(document).ready(function() {
@@ -371,7 +376,6 @@
             });
         });
     </script>
-
 
 
     <!-- DataTables function for calling plotly for low exon plots -->
@@ -553,6 +557,16 @@
         var snp_check = $total_snps
         if (snp_check == 0) { 
         document.getElementById('snps').style.display = "none";  
+        }
+    </script>
+
+
+    <!-- function to conditionally hide low exon plots div if no plots to display -->
+    <script>
+        // $exon_issues is int passed from report script
+        var exon_check = $exon_issues
+        if (exon_check == 0) { 
+        document.getElementById('low_exon_plots').style.display = "none";  
         }
     </script>
 

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -259,26 +259,87 @@
                 <li><b>$snps_covered</b> (<b>$snps_pct_covered %</b>) were covered at or above <b>$threshold</b></li>
                 <li><b>$snps_not_covered</b> (<b>$snps_pct_not_covered %</b>) variants were <b>not</b> covered at <b>$threshold</b></li>
                 <li><b>$snps_out_panel</b> (<b>$snps_pct_out_panel %</b>) variants spanned region boundaries </li>
-                <br>
                 $vcfs
                 </br>
+
                 <!-- snps_no_cov is div passed from script if variants spanning exon boundaries found -->
-                $snps_no_cov
-                Table of variants with low coverage (< $threshold) &nbsp
-                <button class="btn btn-info collapsible btn-sm">Show / hide table</button>
+                <div id="snps_no_cov">
+                    <b>Variants spanning gene/exon boundaries (e.g. larger structural variants)</b>
+                    <!-- Table for exon boundary spanning variants, data in JS function -->
+                    <table id="snps_no_cov_table" class="display" style="width:100%; text-align:center">
+                        <thead>
+                            <tr>
+                                <td> </td>
+                                <td>VCF</td>
+                                <td>Chromosome</td>
+                                <td>Position</td>
+                                <td>Ref</td>
+                                <td>Alt</td>
+                                <td>Info</td>
+                            </tr>
+                        </thead>
+                    </table>
+                </div>
+
+                <br></br>
+
+                <!-- Table for sub threshold exon coverage, data in JS function -->
+                <div id="snps_low_cov">
+                    Table of variants with low coverage (< $threshold) &nbsp
+                    <table id="snps_low_cov_table" class="display" style="width:100%; text-align:center">
+                        <thead>
+                            <tr>
+                                <td> </td>
+                                <td>VCF</td>
+                                <td>Gene</td>
+                                <td>Exon</td>
+                                <td>Chromosome</td>
+                                <td>Position</td>
+                                <td>Ref</td>
+                                <td>Alt</td>
+                                <td>Coverage</td>
+                            </tr>
+                        </thead>
+                    </table>
+                </div>
+
+                <!-- <button class="btn btn-info collapsible btn-sm">Show / hide table</button>
                 <div class="content">
                     <table class="snps" style="table-layout: fixed; width:100%">
                         $snps_low_cov
                     </table>
-                </div>        
-                <br>
-                Table of variants with high coverage (>= $threshold) &nbsp
+                </div> -->
+
+                <!-- 
                 <button class="btn btn-info collapsible btn-sm">Show / hide table</button>
                 <div class="content">
                     <table class="snps" style="table-layout: fixed; width:100%">
                         $snps_high_cov
                     </table>
+                </div> -->
+
+                <br></br>
+
+                <div id="snps_covered">
+                    <b>Table of variants with high coverage (>= $threshold) &nbsp</b>
+                    <!-- Table for above threshold exon coverage, data in JS function -->
+                    <table id="snps_covered_table" class="display" style="width:100%; text-align:center">
+                        <thead>
+                            <tr>
+                                <td> </td>
+                                <td>VCF</td>
+                                <td>Gene</td>
+                                <td>Exon</td>
+                                <td>Chromosome</td>
+                                <td>Position</td>
+                                <td>Ref</td>
+                                <td>Alt</td>
+                                <td>Coverage</td>
+                            </tr>
+                        </thead>
+                    </table>
                 </div>
+
                 </br></br>
             </div>
         </div>
@@ -615,6 +676,7 @@
     <script type="text/javascript" class="init">	
         $(document).ready(function() {
             var data = $total_stats ;
+            
             $('#exon_table').DataTable( {
                 data:           data,
                 deferRender:    true,
@@ -632,5 +694,107 @@
             } );
         } );
     </script>
+
+
+    <!-- DataTables function for variant table - exon boundary spanning -->
+    <script type="text/javascript" class="init">	
+        $(document).ready(function() {
+            var data = $snps_no_cov_data ;
+
+            if ($('data').length == 0) {
+                // empty table, replace with text
+                document.getElementById('snps_low_cov').innerHTML = '';
+                // var h1 = document.createElement('h1');
+                // h1.innerHTML = "hello world!";
+                var text = "<b>No variants spanning gene / exon regions < $threshold</b>"
+                // document.getElementById('snps_low_cov').appendChild(text);
+                document.getElementById('snps_low_cov').innerHTML = text ;
+            }
+
+            $('#snps_no_cov_table').DataTable( {
+                data:           data,
+                deferRender:    true,
+                scrollY:        500,
+                scrollCollapse: true,
+                scroller:       true,
+                scroller: {
+                    loadingIndicator: true
+                },
+                'processing': true,
+                'language': {
+                    'loadingRecords': '&nbsp;',
+                    'processing': 'Loading...'
+                }
+            } );
+        } );
+    </script>
+
+    <!-- DataTables function for variant table - sub-threshold coverage -->
+    <script type="text/javascript" class="init">	
+        $(document).ready(function() {
+            var data = $snps_low_cov_data ;
+
+            if ($('data').length == 0) {
+                // empty table, replace with text
+                document.getElementById('snps_low_cov').innerHTML = '';
+                // var h1 = document.createElement('h1');
+                // h1.innerHTML = "hello world!";
+                var text = "<b>No variants with coverage < $threshold</b>"
+                // document.getElementById('snps_low_cov').appendChild(text);
+                document.getElementById('snps_low_cov').innerHTML = text ;
+            }
+
+            $('#snps_sub_threshold_table').DataTable( {
+                data:           data,
+                deferRender:    true,
+                scrollY:        500,
+                scrollCollapse: true,
+                scroller:       true,
+                scroller: {
+                    loadingIndicator: true
+                },
+                'processing': true,
+                'language': {
+                    'loadingRecords': '&nbsp;',
+                    'processing': 'Loading...'
+                }
+            } );
+        } );
+    </script>
+
+
+    <!-- DataTables function for variant table - above treshold coverage -->
+    <script type="text/javascript" class="init">	
+        $(document).ready(function() {
+            var data = $snps_high_cov_data ;
+
+            if ($('data').length == 0) {
+                // empty table, replace with text
+                document.getElementById('snps_low_cov').innerHTML = '';
+                // var h1 = document.createElement('h1');
+                // h1.innerHTML = "hello world!";
+                var text = "<b>No variants with coverage > $threshold</b>"
+                // document.getElementById('snps_low_cov').appendChild(text);
+                document.getElementById('snps_low_cov').innerHTML = text ;
+            }
+
+            $('#snps_covered_table').DataTable( {
+                data:           data,
+                deferRender:    true,
+                scrollY:        500,
+                scrollCollapse: true,
+                scroller:       true,
+                scroller: {
+                    loadingIndicator: true
+                },
+                'processing': true,
+                'language': {
+                    'loadingRecords': '&nbsp;',
+                    'processing': 'Loading...'
+                }
+            } );
+        } );
+    </script>
+
     </div>
 </html>

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -178,8 +178,6 @@
             </div>
             <br></br>
 
-            <br></br>
-
             To assess what portion of the exon(s) have sub-optimal coverage, the plots below display 
             an interactive window on hovering, showing the coverage at that current base.<br>
             The top right also contains a toolbar, with functions such as panning and zooming.

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -344,7 +344,7 @@
         // $total_snps is int passed from report script, set to JS snp_check var on writing to template to check against
         var snp_check = $total_snps
         if (snp_check == 0) { 
-        document.getElementById('snps').style.display = "none";  
+            document.getElementById('snps').style.display = "none";  
         }
     </script>
 
@@ -354,7 +354,7 @@
         // $exon_issues is int passed from report script
         var exon_check = $exon_issues
         if (exon_check == 0) { 
-        document.getElementById('low_exon_plots').style.display = "none";  
+            document.getElementById('low_exon_plots').style.display = "none";  
         }
     </script>
 
@@ -367,11 +367,12 @@
         for (i = 0; i < coll.length; i++) {
         coll[i].addEventListener("click", function() {
             this.classList.toggle("active");
+
             var content = this.nextElementSibling;
-            if (content.style.maxHeight){
-            content.style.maxHeight = null;
+                if (content.style.maxHeight) {
+                    content.style.maxHeight = null;
             } else {
-            content.style.maxHeight = content.scrollHeight * 2 + "px";
+                content.style.maxHeight = content.scrollHeight * 2 + "px";
             } 
         });
         }

--- a/data/templates/single_template.html
+++ b/data/templates/single_template.html
@@ -165,7 +165,7 @@
 
             $summary_plot
 
-            <br></br><br></br>
+            <br></br><hr><br></br>
         
             <!-- Low covered exons table and plots -->
             <h2>Exons with &lt;100% coverage at $threshold</h2>
@@ -198,7 +198,7 @@
                 </thead>
             </table>
 
-            <br></br><br></br>
+            <br></br><hr><br></br>
 
             <div id="gene">
                 <!-- Per gene table and plots -->
@@ -230,10 +230,10 @@
 
             </div>
 
-            <br></br><br></br>
+            <br></br><hr><br></br>
 
             <div id="exons">
-                <!-- Table for gene level coverage, headings passed from script, data in JS function -->
+                <!-- Table for exon level coverage, headings passed from script, data in JS function -->
                 <h2> Per exon coverage </h2>
                 <br>
                 The following section provides coverage metrics for every exon of each gene.
@@ -246,7 +246,7 @@
                     </thead>
                 </table>
             </div>
-            <br></br>
+            <br><hr></br>
 
             <!-- Optional section for displaying SNP information if generated -->
             <div id="snps">
@@ -259,8 +259,8 @@
                 <li><b>$snps_covered</b> (<b>$snps_pct_covered %</b>) were covered at or above <b>$threshold</b></li>
                 <li><b>$snps_not_covered</b> (<b>$snps_pct_not_covered %</b>) variants were <b>not</b> covered at <b>$threshold</b></li>
                 <li><b>$snps_out_panel</b> (<b>$snps_pct_out_panel %</b>) variants spanned region boundaries </li>
-                $vcfs
-                </br>
+                <li>$vcfs</li>
+                </br></br>
 
                 <!-- snps_no_cov is div passed from script if variants spanning exon boundaries found -->
                 <div id="snps_no_cov">
@@ -281,7 +281,7 @@
                     </table>
                 </div>
 
-                <br></br>
+                <br><hr></br>
 
                 <!-- Table for sub threshold exon coverage, data in JS function -->
                 <div id="snps_low_cov">
@@ -318,7 +318,7 @@
                     </table>
                 </div> -->
 
-                <br></br>
+                <br><hr></br>
 
                 <div id="snps_covered">
                     <b>Table of variants with high coverage (>= $threshold) &nbsp</b>
@@ -761,7 +761,6 @@
             } );
         } );
     </script>
-
 
     <!-- DataTables function for variant table - above treshold coverage -->
     <script type="text/javascript" class="init">	


### PR DESCRIPTION
- add datatables to all 3 SNP tables, gives fixed window scrolling, searching, deferred rendering etc.
- remove styling of SNP tables from Python script
- cleaned up some spacing in report
- added some nice horizontal `<hr>` divider lines between sections
- bonus: added function to hide low exon plots div when no plots to display
- example output here: https://cuhbioinformatics.atlassian.net/wiki/spaces/P/pages/2221441025/v1.1.1+-+1.2.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/athena/46)
<!-- Reviewable:end -->
