### PR TITLE
1.2 - fix rounding for sub-threshold table

### DIFF
--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -479,7 +479,7 @@ class styleTables():
 
         dtypes = {
             'gene': str, 'tx': str, 'chrom': str, 'exon': int, 'exon_len': int,
-            'exon_start': int, 'exon_end': int, 'min': int, 'mean': int,
+            'exon_start': int, 'exon_end': int, 'min': int, 'mean': float,
             'max': int
         }
 

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -528,6 +528,7 @@ class styleTables():
         # add index as column to have numbered rows in report
         sub_threshold_stats.insert(0, ' ', sub_threshold_stats.index)
 
+        # list of threshold columns + mean
         round_cols = ['Mean'] + self.threshold_cols
 
         # limit to 2dp using math.floor, use of round() with

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -485,7 +485,7 @@ class styleTables():
 
         for col in self.threshold_cols:
             # add dtype for threshold columns
-            dtypes[col] = int
+            dtypes[col] = float
 
         sub_threshold = pd.DataFrame(columns=column)
         sub_threshold.astype(dtype=dtypes)
@@ -528,14 +528,14 @@ class styleTables():
         # add index as column to have numbered rows in report
         sub_threshold_stats.insert(0, ' ', sub_threshold_stats.index)
 
-        # make dict for rounding coverage columns to 2dp
-        rnd = {}
-        for col in list(sub_threshold_stats.columns[10:]):
-            rnd[col] = '{0:.2f}%'
+        round_cols = ['Mean'] + self.threshold_cols
 
-        sub_threshold_stats["Mean"] = sub_threshold_stats["Mean"].apply(
-            lambda x: int(x)
-        )
+        # limit to 2dp using math.floor, use of round() with
+        # 2dp may lead to inaccuracy such as 99.99 => 100.00
+        for col in round_cols:
+            sub_threshold_stats[col] = sub_threshold_stats[col].map(
+                lambda col: math.floor(col * 100) / 100
+            )
 
         # generate list of dicts with column headers for styling
         low_exon_columns = []

--- a/bin/coverage_report_single.py
+++ b/bin/coverage_report_single.py
@@ -436,7 +436,10 @@ class generatePlots():
 class styleTables():
     """Functions for styling tables for displaying in report"""
 
-    def __init__(self, cov_stats, cov_summary, threshold, threshold_cols, vals):
+    def __init__(
+        self, cov_stats: pd.DataFrame, cov_summary: pd.DataFrame,
+        threshold: str, threshold_cols: list, vals: list
+    ) -> None:
         self.cov_stats = cov_stats
         self.cov_summary = cov_summary
         self.threshold = threshold
@@ -461,10 +464,6 @@ class styleTables():
         """
         Styling of sub threshold stats df for displaying in report
 
-        Args:
-            - cov_stats (df): df of per exon coverage stats
-            - threshold (str): low coverage threshold value
-            - threshold_cols (list): threshold values for coverage
         Returns:
             - sub_threshold_stats (list): list of sub threshold coverage stats
             - low_exon_columns (list): list of column headers for report
@@ -528,7 +527,7 @@ class styleTables():
         # add index as column to have numbered rows in report
         sub_threshold_stats.insert(0, ' ', sub_threshold_stats.index)
 
-        # list of threshold columns + mean
+        # threshold_cols -> list of strings, add mean to loop over for rounding
         round_cols = ['Mean'] + self.threshold_cols
 
         # limit to 2dp using math.floor, use of round() with


### PR DESCRIPTION
- values in sub-threshold table were set to int and therefore lost all decimal places
- set to float and applied same floor division as other places to limit all to 2 d.p

before:

![image](https://user-images.githubusercontent.com/45037268/124588112-5a612d00-de50-11eb-9880-950a4ca0928c.png)

after:

![image](https://user-images.githubusercontent.com/45037268/124594960-50dbc300-de58-11eb-87f5-e4bd93f3d413.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/athena/48)
<!-- Reviewable:end -->
