### PR TITLE
fix sqlalchemy package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ pandasql==0.7.3
 Pillow==7.2.0
 plotly==4.9.0
 pybedtools==0.8.1
+SQLAlchemy==1.3.20
 zipp==3.1.0


### PR DESCRIPTION
SQLAlchemy package version needs fixing due to incompatibility between pandasql and sqlalchemy >2.0.0, fixed to be same version as previously in eggd_athena

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/athena/90)
<!-- Reviewable:end -->
