### PR TITLE
fix to ensure panel string always passed as string

### DIFF
--- a/dnanexus/src/eggd_athena.sh
+++ b/dnanexus/src/eggd_athena.sh
@@ -83,7 +83,7 @@ main() {
 
     if [ "$cutoff_threshold" ]; then report_args+=" --threshold $cutoff_threshold"; fi
     if [ "$name" ]; then report_args+=" --sample_name $name"; fi
-    if [ "$panel" = true ]; then report_args+=" --panel $panel_bed_name"; fi
+    if [ "$panel" = true ]; then report_args+=" --panel \"$panel_bed_name\" "; fi
     if [ "$indication" ]; then report_args+=" --indication \"$indication\" "; fi
     if [ "$panel_filters" ]; then report_args+=" --panel_filters ${panel_filters} "; fi
     if [ "$summary" = true ]; then report_args+=" --summary"; fi


### PR DESCRIPTION
switching to running reports with `eval` causes an error if `&&` present in panel name string as bash interprets this as 2 commands, ensure this is always treat as a string by adding additional escaped quotes

test job: https://platform.dnanexus.com/panx/projects/GbYYYK84pz077xXpJVzVjQ1j/monitor/job/Gbj6vPQ4pz086B2yqJz0g44Y

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/athena/92)
<!-- Reviewable:end -->
